### PR TITLE
Avoid unnecessary conversions

### DIFF
--- a/main.py
+++ b/main.py
@@ -196,7 +196,7 @@ def main():
         x.start()
 
     # Don't need that I think. Should implement restarting of a thread if function fails for some reason
-    for index, thread in enumerate(threads):
+    for thread in threads:
         thread.join()
 
 


### PR DESCRIPTION
Enumerating this list is unnecessary. Similar code like this can be found at other places. Not necessarily always an enumeration, but things like converting a list to a list, converting a tuple to a list just to iterate over it or converting a string to a string.