### PR TITLE
Fix Panasonic Preset Numbering

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,13 +25,12 @@ def setPreset(preset, camera, manufacturer, verbose=False):
         print(camera, manufacturer)
         if manufacturer == "panasonic":
             print("PANASONIC")
-            if preset < 10:
-                preset = "0" + str(preset)
-
-            url = camera + '/cgi-bin/aw_ptz?cmd=%23R' + str(preset) + '&res=1'
+            params = {'cmd': f'#R{preset - 1:02}', 'res': 1}
+            url = f'{camera}/cgi-bin/aw_ptz'
+            auth = ('<user>', '<password>')
             if verbose:
                 print("URL:" + url)
-            code = requests.get(url, auth=("<user>", "<password>"))
+            code = requests.get(url, auth=auth, params=params)
         elif manufacturer == "sony":
             print("SONY")
             preset = int(preset)


### PR DESCRIPTION
This patch fixes the preset numbering for Panasonic cameras. Before, the specified and the executed presets were off by one. For example, this would actually try turing the camera to preset 11 instead of 10:

```py
setPreset(10, 'http://...', 'panasonic')
```