### PR TITLE
Overhaul position triggers

### DIFF
--- a/camera-control.yml
+++ b/camera-control.yml
@@ -10,8 +10,8 @@ opencast:
   password: opencast
 
 calendar:
-  # The frequency in which the calendar should be updated
-  update_frequency: 60
+  # The frequency in which the calendar should be updated in seconds
+  update_frequency: 120
 
 # Camera Configuration
 # Configure the capture agents to get the calendar for and a list of cameras to


### PR DESCRIPTION
This patch updates the main control loop to trigger camera position changes. It will now:

- Update the schedule on a regular (configurable) basis
- Move to camera positions even if the control is slightly late
- Initially move the camera to a neutral position

This does not yet move the calendar updates to a separate thread.

This fixes #6
This fixes #8