### PR TITLE
Introduce flak8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: run flake8
+
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # https://endoflife.date/python
+        # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#python
+        python-version:
+          - '3.9'
+          - '3.10'
+          - '3.11'
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: set up python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - run: pip install -r requirements.txt
+
+    - run: pip install flake8
+
+    - run: flake8 --max-line-length 140 *.py

--- a/main.py
+++ b/main.py
@@ -16,7 +16,6 @@
 
 import argparse
 import requests
-import json
 import time
 import threading
 
@@ -31,10 +30,7 @@ from requests.auth import HTTPDigestAuth
 # Works
 def getCutoff():
     # calculate the offset of now + 1 week
-    cutoff = (round(time.time()) + 7*24*60*60)*1000
-
-    #print("Cutoff =",cutoff)
-    return cutoff
+    return (int(time.time()) + 7*24*60*60)*1000
 
 
 # Works fine for now

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-confygure
+confygure >= 0.0.3
 requests


### PR DESCRIPTION
This patch adds a GitHub Actions workflow which runs `flake8` as style checker and basic static code analysis tool.

For now, this still excludes the line length check. We should get to that eventually, but most of the warnings probably get fixed when we address #7 and introduce a logger anyway.