### PR TITLE
Add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+build/
+dist/
+*.egg-info/
+
+# Environment
+venv/
+
+# Editor
+.vscode
+*.swp


### PR DESCRIPTION
This patch adds a `.gitignore` for the usual Python files we don't want to commit.