### PR TITLE
Make cutoff date configurable

### DIFF
--- a/camera-control.yml
+++ b/camera-control.yml
@@ -13,6 +13,11 @@ calendar:
   # The frequency in which the calendar should be updated in seconds
   update_frequency: 120
 
+  # How far in the future should calendar items be cached
+  # Seconds fro when the calendar is requested.
+  # Default: 604800 (7 days)
+  cutoff: 604800
+
 # Camera Configuration
 # Configure the capture agents to get the calendar for and a list of cameras to
 # control when a capture agent starts.

--- a/occameracontrol/agent.py
+++ b/occameracontrol/agent.py
@@ -54,11 +54,11 @@ class Agent:
     def __init__(self, agent_id: str):
         self.agent_id = agent_id
 
-    def cutoff(self):
-        ''' calculate the offset of now + 1 week
+    def cutoff(self) -> int:
+        '''Returns the calendar cutoff time in milliseconds.
         '''
-        # TODO: make cutoff date configurable
-        return (int(time.time()) + 7*24*60*60)*1000
+        cutoff_seconds = config('calendar', 'cutoff') or (7 * 24 * 60 * 60)
+        return (int(time.time()) + cutoff_seconds) * 1000
 
     def parse_calendar(self, cal):
         '''Take the calendar data from Opencast and return a list of event data.


### PR DESCRIPTION
This patch allows users to configure the calendar cutoff for calendars retrieved from Opencast.