### PR TITLE
Set HTTP timeouts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,8 @@ jobs:
 
     - run: pip install -r requirements.txt
 
-    - run: pip install flake8
+    - run: pip install flake8 bandit
 
     - run: flake8 --max-line-length 100 occameracontrol
+
+    - run: bandit -r occameracontrol

--- a/occameracontrol/agent.py
+++ b/occameracontrol/agent.py
@@ -85,7 +85,7 @@ class Agent:
 
         logger.info('Updating calendar for agent `%s`', self.agent_id)
 
-        response = requests.get(url, auth=auth, params=params)
+        response = requests.get(url, auth=auth, params=params, timeout=5)
         response.raise_for_status()
 
         calendar = response.json()

--- a/occameracontrol/camera.py
+++ b/occameracontrol/camera.py
@@ -68,7 +68,7 @@ class Camera:
             url = f'{self.url}/cgi-bin/aw_ptz'
             auth = (self.user, self.password) if self.user else None
             logger.debug('GET %s with params: %s', url, params)
-            response = requests.get(url, auth=auth, params=params)
+            response = requests.get(url, auth=auth, params=params, timeout=5)
             response.raise_for_status()
 
         elif self.type == CameraType.sony:
@@ -77,7 +77,11 @@ class Camera:
             auth = HTTPDigestAuth(self.user, self.password)
             headers = {'referer': f'{self.url}/'}
             logger.debug('GET %s with params: %s', url, params)
-            response = requests.get(url, auth=auth, headers=headers, params=params)
+            response = requests.get(url,
+                                    auth=auth,
+                                    headers=headers,
+                                    params=params,
+                                    timeout=5)
             response.raise_for_status()
 
         self.position = preset


### PR DESCRIPTION
This patch adds a `timeout` parameter to request requests. This prevents the requests from potentially hanging indefinitely.

This fixes #21