### PR TITLE
Switch from milliseconds to seconds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,6 @@ jobs:
 
     - run: pip install flake8 bandit
 
-    - run: flake8 --max-line-length 100 occameracontrol
+    - run: flake8 occameracontrol
 
     - run: bandit -r occameracontrol

--- a/occameracontrol/agent.py
+++ b/occameracontrol/agent.py
@@ -36,15 +36,13 @@ class Event:
         self.end = end
 
     def active(self):
-        now = int(time.time()) * 1000
-        return self.start <= now < self.end
+        return self.start <= time.time() < self.end
 
     def future(self):
-        now = int(time.time()) * 1000
-        return now < self.start < self.end
+        return time.time() < self.start < self.end
 
     def __str__(self):
-        return f'{self.title} (start: {self.start}, end: {self.end})'
+        return f'{self.title} (start: {self.start:.3f}, end: {self.end:.3f})'
 
 
 class Agent:
@@ -67,8 +65,8 @@ class Agent:
         for event in cal:
             data = event['data']
             title = data['agentConfig']['event.title']
-            start = int(parse(data['startDate'], dayfirst=True).timestamp() * 1000)
-            end = int(parse(data['endDate'], dayfirst=True).timestamp() * 1000)
+            start = parse(data['startDate'], dayfirst=True).timestamp()
+            end = parse(data['endDate'], dayfirst=True).timestamp()
             event = Event(title, start, end)
 
             logger.debug('Got event %s', event)
@@ -97,8 +95,8 @@ class Agent:
         '''Return a list of active events
         '''
         # Remove old events from cached events
-        now = int(time.time()) * 1000
-        return [e for e in self.events if e.end > now]
+        now = time.time()
+        return [e for e in self.events if e.end >= now]
 
     def next_event(self):
         events = self.active_events()

--- a/occameracontrol/camera.py
+++ b/occameracontrol/camera.py
@@ -87,28 +87,27 @@ class Camera:
         self.position = preset
 
     def update_position(self):
-        now = int(time.time()) * 1000
         agent_id = self.agent.agent_id
         event = self.agent.next_event()
 
         if event.future():
-            logger.info('[%s] Next event `%s` starts in %s seconds',
-                        agent_id, event.title, (event.start - now) / 1000)
+            logger.info('[%s] Next event `%s` starts in %i seconds',
+                        agent_id, event.title, event.start - time.time())
         elif event.active():
-            logger.info('[%s] Active event `%s` ends in %s seconds',
-                        agent_id, event.title, (event.end - now) / 1000)
+            logger.info('[%s] Active event `%s` ends in %i seconds',
+                        agent_id, event.title, event.end - time.time())
         else:
             logger.info('[%s] No planned events', agent_id)
 
         if event.active():
             if self.position != self.preset_active:
                 logger.info('[%s] Event `%s` started', agent_id, event.title)
-                logger.info('[%s] Moving to preset %s', agent_id,
+                logger.info('[%s] Moving to preset %i', agent_id,
                             self.preset_active)
                 self.move_to_preset(self.preset_active)
 
         else:  # No active event
             if self.position != self.preset_inactive:
-                logger.info('[%s] Returning to preset %s', agent_id,
+                logger.info('[%s] Returning to preset %i', agent_id,
                             self.preset_inactive)
                 self.move_to_preset(self.preset_inactive)


### PR DESCRIPTION
This patch removes the conversion of all time values to milliseconds. We don't need to do that since we literally convert every time.

This fixes #27
This fixes #4